### PR TITLE
Add Azure resources for private networking and DNS configuration

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -29,6 +29,23 @@ data "azurerm_resource_group" "rg" {
     name = var.resource_group_name
 }
 
+# Virtual network and subnet
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.storage_account_name}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "private-endpoint-subnet"
+  resource_group_name  = data.azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+  
+  private_endpoint_network_policies_enabled = true
+}
+
 # storage account
 resource "azurerm_storage_account" "storage" {
     name                          = var.storage_account_name
@@ -36,9 +53,48 @@ resource "azurerm_storage_account" "storage" {
     location                      = data.azurerm_resource_group.rg.location
     account_tier                  = "Standard"
     account_replication_type      = "LRS"
-    enable_https_traffic_only     = true
+    https_traffic_only_enabled    = true
     shared_access_key_enabled     = false
-    # public_network_access_enabled = false
+    public_network_access_enabled = false
+}
+
+# Private endpoint for the storage account
+resource "azurerm_private_endpoint" "endpoint" {
+  name                = "${var.storage_account_name}-endpoint"
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+  subnet_id           = azurerm_subnet.subnet.id
+
+  private_service_connection {
+    name                           = "${var.storage_account_name}-privateserviceconnection"
+    private_connection_resource_id = azurerm_storage_account.storage.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+}
+
+# Private DNS zone for blob storage
+resource "azurerm_private_dns_zone" "private_dns" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+# Link the private DNS zone to the virtual network
+resource "azurerm_private_dns_zone_virtual_network_link" "dns_link" {
+  name                  = "${var.storage_account_name}-dnslink"
+  resource_group_name   = data.azurerm_resource_group.rg.name
+  private_dns_zone_name = azurerm_private_dns_zone.private_dns.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+  registration_enabled  = true
+}
+
+# DNS A Record for the private endpoint
+resource "azurerm_private_dns_a_record" "dns_a" {
+  name                = var.storage_account_name
+  zone_name           = azurerm_private_dns_zone.private_dns.name
+  resource_group_name = data.azurerm_resource_group.rg.name
+  ttl                 = 300
+  records             = [azurerm_private_endpoint.endpoint.private_service_connection[0].private_ip_address]
 }
 
 # STATE_RESOURCE_GROUP=xxxx


### PR DESCRIPTION
This pull request introduces several new resources and updates to the existing infrastructure configuration in `infra/main.tf`. The main changes include the addition of a virtual network, subnet, private endpoint, and DNS configurations. Additionally, there are updates to the storage account settings.

### New Resources Added:
* Added `azurerm_virtual_network` resource to create a virtual network.
* Added `azurerm_subnet` resource to create a subnet within the virtual network.
* Added `azurerm_private_endpoint` resource to create a private endpoint for the storage account.
* Added `azurerm_private_dns_zone` resource to create a private DNS zone for blob storage.
* Added `azurerm_private_dns_zone_virtual_network_link` resource to link the private DNS zone to the virtual network.
* Added `azurerm_private_dns_a_record` resource to create a DNS A record for the private endpoint.

### Updates to Existing Resources:
* Updated `azurerm_storage_account` resource to use `https_traffic_only_enabled` instead of `enable_https_traffic_only`.
* Enabled `public_network_access_enabled` for